### PR TITLE
Adding Mocking Tool initial implementation

### DIFF
--- a/modules/testerina-core/pom.xml
+++ b/modules/testerina-core/pom.xml
@@ -18,25 +18,65 @@
     <url>http://wso2.org</url>
 
     <dependencies>
-
         <dependency>
             <groupId>org.wso2.ballerina</groupId>
             <artifactId>ballerina-core</artifactId>
-            <version>${ballerina.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.ballerina</groupId>
+            <artifactId>annotation-processor</artifactId>
         </dependency>
 
         <!-- Dependencies for ballerina command: test -->
         <dependency>
             <groupId>org.wso2.ballerina</groupId>
             <artifactId>ballerina-launcher</artifactId>
-            <version>${ballerina.launcher.version}</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
             <version>${com.beust.jcommander.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.wso2.orbit.org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+        </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <!-- For ballerina annotation processing -->
+            <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+                <version>${mvn.processor.plugin.version}</version>
+                <configuration>
+                    <processors>
+                        <processor>org.wso2.ballerina.annotation.processor.BallerinaAnnotationProcessor</processor>
+                    </processors>
+                    <options>
+                        <packageName>${native.constructs.provider.package}</packageName>
+                        <className>${native.constructs.provider.class}</className>
+                    </options>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>process</id>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <native.constructs.provider.package>org.ballerinalang.mockerina.nativeimpl</native.constructs.provider.package>
+        <native.constructs.provider.class>MockerinaNativeConstructsProvider</native.constructs.provider.class>
+        <mvn.processor.plugin.version>2.2.4</mvn.processor.plugin.version>
+
+        <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
+    </properties>
 </project>

--- a/modules/testerina-core/src/main/java/org/ballerinalang/mockerina/MockerinaRegistry.java
+++ b/modules/testerina-core/src/main/java/org/ballerinalang/mockerina/MockerinaRegistry.java
@@ -1,0 +1,65 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.mockerina;
+
+import org.wso2.ballerina.core.model.BallerinaFile;
+import org.wso2.ballerina.core.model.Service;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Keep a registry of {@code {@link BallerinaFile}} instances.
+ * This is required to modify the runtime behavior.
+ */
+public class MockerinaRegistry {
+    private static Map<BallerinaFile, BallerinaFile> bFiles = new HashMap<>();
+    private static Map<String, Service> services = new HashMap<>(); //todo remove?
+    private static final MockerinaRegistry instance = new MockerinaRegistry();
+
+    public static MockerinaRegistry getInstance() {
+        return instance;
+    }
+
+    public void addBallerinaFile(BallerinaFile originalBFile, BallerinaFile derivativeBFile) {
+        bFiles.put(originalBFile, derivativeBFile);
+    }
+
+    public BallerinaFile[] getOriginalBallerinaFiles() {
+        return bFiles.keySet().toArray(new BallerinaFile[bFiles.size()]);
+    }
+
+    public BallerinaFile getDerivativeBallerinaFile(BallerinaFile bFile) {
+        return bFiles.get(bFile);
+    }
+
+    public BallerinaFile resolve(Service service) {
+        return bFiles.keySet().stream().filter(ballerinaFile ->
+                Arrays.stream(ballerinaFile.getServices()).anyMatch(s -> s.equals(service)))
+                .findAny().orElse(null);
+    }
+
+    public void addService(Service service) {
+        services.put(service.getName(), service);
+    }
+
+    public Service getService(String serviceName) {
+        return services.get(serviceName);
+    }
+}

--- a/modules/testerina-core/src/main/java/org/ballerinalang/mockerina/nativeimpl/StartService.java
+++ b/modules/testerina-core/src/main/java/org/ballerinalang/mockerina/nativeimpl/StartService.java
@@ -1,0 +1,133 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.mockerina.nativeimpl;
+
+import org.ballerinalang.mockerina.MockerinaRegistry;
+import org.wso2.ballerina.core.exception.BallerinaException;
+import org.wso2.ballerina.core.interpreter.Context;
+import org.wso2.ballerina.core.interpreter.RuntimeEnvironment;
+import org.wso2.ballerina.core.model.Application;
+import org.wso2.ballerina.core.model.BallerinaFile;
+import org.wso2.ballerina.core.model.Package;
+import org.wso2.ballerina.core.model.Resource;
+import org.wso2.ballerina.core.model.Service;
+import org.wso2.ballerina.core.model.types.TypeEnum;
+import org.wso2.ballerina.core.model.values.BString;
+import org.wso2.ballerina.core.model.values.BValue;
+import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
+import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
+import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
+import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
+import org.wso2.ballerina.core.runtime.dispatching.ServiceDispatcher;
+import org.wso2.ballerina.core.runtime.registry.ApplicationRegistry;
+import org.wso2.ballerina.core.runtime.registry.DispatcherRegistry;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Native function ballerina.lang.mock:startServer.
+ *
+ * @since 0.8.0
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.mock",
+        functionName = "startService", args = {
+        @Argument(name = "serviceName", type = TypeEnum.STRING) }, returnType = {
+        @ReturnType(type = TypeEnum.STRING) }, isPublic = true)
+public class StartService extends AbstractNativeFunction {
+
+    static String getFileName(Path sourceFilePath) {
+        Path fileNamePath = sourceFilePath.getFileName();
+        return (fileNamePath != null) ? fileNamePath.toString() : sourceFilePath.toString();
+    }
+
+    /**
+     *
+     * Starts the service specified in the 'serviceName' argument.
+     *
+     * The MockerinaRegistry has the original BallerinaFile with all the services.
+     * It also contain the corresponding actual BallerinaFile object without any services. (the derivativeBFile)
+     * An Application named 'default' is registered for the derivativeBFile.
+     *
+     */
+    @Override
+    public BValue[] execute(Context ctx) {
+        String serviceName = getArgument(ctx, 0).stringValue();     //todo only one service for now
+
+        Application app = ApplicationRegistry.getInstance().getApplication("default");
+        Optional<Service> matchingService = Optional.empty();
+        for (BallerinaFile aBallerinaFile : MockerinaRegistry.getInstance().getOriginalBallerinaFiles()) {
+            Service[] services = aBallerinaFile.getServices();
+
+            // 1) First, we get the Service for the given serviceName from the original BallerinaFile
+            matchingService = Arrays.stream(services).filter(s -> s.getName().equals(serviceName)).findAny();
+            if (!matchingService.isPresent()) {
+                continue;
+            } else {
+                // 2) Then, we append that to the list of services in the derivativeBFile.
+                BallerinaFile derivativeBallerinaFile = MockerinaRegistry.getInstance()
+                        .getDerivativeBallerinaFile(aBallerinaFile); //the actual bfile registered in AppRegistry
+                addService(app, matchingService.get(), derivativeBallerinaFile);
+            }
+
+        }
+
+        // 5) fail if no matching service for the given 'serviceName' argument is found.
+        if (!matchingService.isPresent()) {
+            StringBuilder listOfServices = new StringBuilder();
+            Arrays.stream(MockerinaRegistry.getInstance().getOriginalBallerinaFiles())
+                    .map(BallerinaFile::getServices)
+                    .flatMap(Arrays::stream)
+                    .forEachOrdered(service -> listOfServices.append(service.getSymbolName().getName()).append(", "));
+            throw new BallerinaException("No service with the name " + serviceName + " found. "
+                    + "Did you mean to start one of these services? " + listOfServices);
+        }
+
+        // 6) return the service url
+        BString str = (BString) getArgument(ctx, 0); //todo return the service url
+        return getBValues(str);
+    }
+
+    private void addService(Application app, Service matchingService, BallerinaFile derivativeBallerinaFile) {
+
+        Service[] registeredServices = derivativeBallerinaFile.getServices();
+        registeredServices = Arrays.copyOf(registeredServices, registeredServices.length + 1);
+        registeredServices[registeredServices.length - 1] = matchingService;
+        derivativeBallerinaFile.setServices(registeredServices);
+
+        // 3) re-generate the runtime environment for the modified bfile
+        RuntimeEnvironment runtimeEnvironment = RuntimeEnvironment.get(derivativeBallerinaFile);
+        app.setRuntimeEnv(runtimeEnvironment);
+        // as done in org.ballerinalang.testerina.core.TestRunner
+        for (Resource resource : matchingService.getResources()) {
+            resource.setApplication(app);
+        }
+
+        Package aPackage = app.getPackage("default");
+        aPackage.getServices().add(matchingService);
+
+        // 4) inform the service dispatchers
+        //ApplicationRegistry.getInstance().updatePackage(aPackage);
+        for (ServiceDispatcher serviceDispatcher : DispatcherRegistry.getInstance().getServiceDispatchers().values()) {
+            serviceDispatcher.serviceRegistered(matchingService);
+        }
+    }
+
+}

--- a/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestCmd.java
+++ b/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestCmd.java
@@ -34,6 +34,10 @@ public class TestCmd implements BLauncherCmd {
 
     @Parameter(arity = 1, description = "arguments")
     private List<String> argList;
+
+    @Parameter(names = "--debug", hidden = true)
+    private String debugPort;
+
     TestRunner testRunner = new TestRunner();
 
     public void execute() {
@@ -41,9 +45,8 @@ public class TestCmd implements BLauncherCmd {
             throw LauncherUtils.createUsageException("no ballerina program or folder given to run tests");
         }
 
-        Path p = Paths.get(argList.get(0));
-        p = p.toAbsolutePath();
-        testRunner.runMain(p);
+        Path[] paths = argList.stream().map(Paths::get).toArray(Path[]::new);
+        TestRunner.runTest(paths);
     }
 
     @Override

--- a/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestRunner.java
+++ b/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestRunner.java
@@ -109,7 +109,7 @@ public class TestRunner {
             //populate applications without services
             BallerinaFile bFile = getBFileWithoutServices(originalBFile, sourceFilePath);
             mockerinaRegistry.addBallerinaFile(originalBFile, bFile);
-            Arrays.stream(originalBFile.getServices())          // save the services list for later use by StartServer
+            Arrays.stream(originalBFile.getServices())          // save the services list for later use by StartService
                     .forEachOrdered(mockerinaRegistry::addService);
 
             // Create a runtime environment for this Ballerina application

--- a/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestRunner.java
+++ b/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestRunner.java
@@ -19,18 +19,47 @@ package org.ballerinalang.testerina.core;
 
 //import org.ballerinalang.testerina.core.langutils.Functions;
 
+import org.ballerinalang.mockerina.MockerinaRegistry;
 import org.ballerinalang.testerina.core.entity.TesterinaFile;
 import org.ballerinalang.testerina.core.entity.TesterinaFunction;
 import org.ballerinalang.testerina.core.langutils.ParserUtils;
 import org.wso2.ballerina.core.exception.BallerinaException;
+import org.wso2.ballerina.core.interpreter.BLangExecutor;
+import org.wso2.ballerina.core.interpreter.CallableUnitInfo;
+import org.wso2.ballerina.core.interpreter.Context;
+import org.wso2.ballerina.core.interpreter.RuntimeEnvironment;
+import org.wso2.ballerina.core.interpreter.StackFrame;
+import org.wso2.ballerina.core.interpreter.StackVarLocation;
+import org.wso2.ballerina.core.model.Application;
 import org.wso2.ballerina.core.model.BallerinaFile;
+import org.wso2.ballerina.core.model.BallerinaFunction;
 import org.wso2.ballerina.core.model.GlobalScope;
+import org.wso2.ballerina.core.model.NodeLocation;
+import org.wso2.ballerina.core.model.Package;
+import org.wso2.ballerina.core.model.ParameterDef;
+import org.wso2.ballerina.core.model.Resource;
+import org.wso2.ballerina.core.model.Service;
+import org.wso2.ballerina.core.model.SymbolName;
 import org.wso2.ballerina.core.model.SymbolScope;
+import org.wso2.ballerina.core.model.expressions.Expression;
+import org.wso2.ballerina.core.model.expressions.FunctionInvocationExpr;
+import org.wso2.ballerina.core.model.expressions.VariableRefExpr;
+import org.wso2.ballerina.core.model.types.BTypes;
+import org.wso2.ballerina.core.model.values.BArray;
+import org.wso2.ballerina.core.model.values.BString;
+import org.wso2.ballerina.core.model.values.BValue;
+import org.wso2.ballerina.core.nativeimpl.connectors.BallerinaConnectorManager;
+import org.wso2.ballerina.core.runtime.MessageProcessor;
+import org.wso2.ballerina.core.runtime.errors.handler.ErrorHandlerUtils;
+import org.wso2.ballerina.core.runtime.registry.ApplicationRegistry;
 
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.logging.Logger;
 
 //import org.wso2.ballerina.core.model.BallerinaFile;
@@ -44,6 +73,136 @@ public class TestRunner {
     private BallerinaFile bFile;
 
     private static final Logger logger = java.util.logging.Logger.getLogger("TestRunner");
+//    private static PrintStream outStream = System.err;
+
+
+    public static void runTest(Path[] sourceFilePaths) {
+        BallerinaConnectorManager.getInstance().initialize(new MessageProcessor());
+
+        Path sourceFilePath = sourceFilePaths[0]; //todo
+        BallerinaFile bFile = ParserUtils.buildLangModel(sourceFilePath);
+
+        // Load Client Connectors
+        BallerinaConnectorManager.getInstance().initializeClientConnectors(new MessageProcessor());
+
+        // Check whether there is a main function
+        BallerinaFunction function = (BallerinaFunction) bFile.getMainFunction();
+        if (function == null) {
+            String pkgString = (bFile.getPackagePath() != null) ? "in package " + bFile.getPackagePath() : "";
+            pkgString = (pkgString.equals("")) ? "in file '" + ParserUtils.getFileName(sourceFilePath) + "'" : "";
+            String errorMsg = "ballerina: main method not found " + pkgString + "";
+            throw new BallerinaException(errorMsg);
+        }
+
+        buildApplicationModel(bFile, sourceFilePath, "default");
+
+
+        execute(bFile, function, Collections.emptyList());
+
+        Runtime.getRuntime().exit(0);
+    }
+
+    private static void buildApplicationModel(BallerinaFile originalBFile, Path sourceFilePath, String appName) {
+        try {
+            MockerinaRegistry mockerinaRegistry = MockerinaRegistry.getInstance();
+
+            //populate applications without services
+            BallerinaFile bFile = getBFileWithoutServices(originalBFile, sourceFilePath);
+            mockerinaRegistry.addBallerinaFile(originalBFile, bFile);
+            Arrays.stream(originalBFile.getServices())          // save the services list for later use by StartServer
+                    .forEachOrdered(mockerinaRegistry::addService);
+
+            // Create a runtime environment for this Ballerina application
+            RuntimeEnvironment runtimeEnv = RuntimeEnvironment.get(bFile);
+
+            // Get the existing application associated with this ballerina config
+            Application app = ApplicationRegistry.getInstance().getApplication(appName);
+            if (app == null) {
+                // Create a new application with ballerina file name, if there is no app currently exists.
+                app = new Application(appName);
+                app.setRuntimeEnv(runtimeEnv);
+                ApplicationRegistry.getInstance().registerApplication(app);
+            }
+
+            Package aPackage = app.getPackage(appName);
+            if (aPackage == null) {
+                // check if package name is null
+//                if (bFile.getPackagePath() != null) {
+//                    aPackage = new Package(bFile.getPackagePath());
+//                } else {
+                aPackage = new Package("default");
+//                }
+                app.addPackage(aPackage);
+            }
+            aPackage.addFiles(bFile);
+
+            // Here we need to link all the resources with this application. We execute the matching resource
+            // when a request is made. At that point, we need to access runtime environment to execute the resource.
+            for (Service service : bFile.getServices()) {
+                for (Resource resource : service.getResources()) {
+                    resource.setApplication(app);
+                }
+            }
+
+           ApplicationRegistry.getInstance().updatePackage(aPackage);
+            //outStream.println("ballerina: deployed service(s) in " + LauncherUtils.getFileName(serviceFilePath));
+        } catch (Throwable e) {
+            throw new BallerinaException(e.getMessage());
+        }
+
+    }
+
+    private static BallerinaFile getBFileWithoutServices(BallerinaFile originalBFile, Path sourceFilePath) {
+        BallerinaFile bFile = ParserUtils.buildLangModel(sourceFilePath);
+        bFile.setServices(new Service[0]);
+        return bFile;
+    }
+
+    private static void execute(BallerinaFile balFile, BallerinaFunction function, List<String> args) {
+        Context bContext = new Context();
+        try {
+            SymbolName argsName;
+            NodeLocation funcLocation = function.getNodeLocation();
+            ParameterDef[] parameterDefs = function.getParameterDefs();
+            argsName = parameterDefs[0].getSymbolName();
+
+            Expression[] exprs = new Expression[1];
+            VariableRefExpr variableRefExpr = new VariableRefExpr(funcLocation, argsName);
+            variableRefExpr.setVariableDef(parameterDefs[0]);
+            StackVarLocation location = new StackVarLocation(0);
+            variableRefExpr.setMemoryLocation(location);
+            variableRefExpr.setType(BTypes.typeString);
+            exprs[0] = variableRefExpr;
+
+            BArray<BString> arrayArgs = new BArray<>(BString.class);
+            for (int i = 0; i < args.size(); i++) {
+                arrayArgs.add(i, new BString(args.get(i)));
+            }
+            BValue[] argValues = {arrayArgs};
+
+            // 3) Create a function invocation expression
+            FunctionInvocationExpr funcIExpr = new FunctionInvocationExpr(funcLocation,
+                    function.getName(), null, function.getPackagePath(), exprs);
+            funcIExpr.setOffset(1);
+            funcIExpr.setCallableUnit(function);
+
+            CallableUnitInfo functionInfo = new CallableUnitInfo(funcIExpr.getName(),
+                    funcIExpr.getPackagePath(), funcLocation);
+
+            StackFrame currentStackFrame = new StackFrame(argValues, new BValue[0], functionInfo);
+            bContext.getControlStack().pushFrame(currentStackFrame);
+
+            RuntimeEnvironment runtimeEnv = RuntimeEnvironment.get(balFile);
+            BLangExecutor executor = new BLangExecutor(runtimeEnv, bContext);
+            funcIExpr.executeMultiReturn(executor);
+
+            bContext.getControlStack().popFrame();
+        } catch (Throwable ex) {
+            String errorMsg = ErrorHandlerUtils.getErrorMessage(ex);
+            String stacktrace = ErrorHandlerUtils.getMainFuncStackTrace(bContext, ex);
+            throw new BallerinaException(errorMsg + "\n" + stacktrace);
+        }
+    }
 
     public void runMain(Path sourceFilePath) {
 

--- a/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/langutils/ParserUtils.java
+++ b/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/langutils/ParserUtils.java
@@ -19,6 +19,10 @@ package org.ballerinalang.testerina.core.langutils;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.wso2.ballerina.core.exception.BallerinaException;
+import org.wso2.ballerina.core.exception.LinkerException;
+import org.wso2.ballerina.core.exception.SemanticException;
 import org.wso2.ballerina.core.interpreter.SymScope;
 import org.wso2.ballerina.core.model.BLangPackage;
 import org.wso2.ballerina.core.model.BallerinaFile;
@@ -30,12 +34,18 @@ import org.wso2.ballerina.core.parser.BallerinaLexer;
 import org.wso2.ballerina.core.parser.BallerinaParser;
 import org.wso2.ballerina.core.parser.BallerinaParserErrorStrategy;
 import org.wso2.ballerina.core.parser.antlr4.BLangAntlr4Listener;
+import org.wso2.ballerina.core.runtime.internal.BuiltInNativeConstructLoader;
 import org.wso2.ballerina.core.semantics.SemanticAnalyzer;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Path;
+
+import static org.ballerinalang.launcher.LauncherUtils.createUsageException;
 
 /**
  * Utility methods for Ballerina Parser.
@@ -45,6 +55,64 @@ import java.net.URL;
 public class ParserUtils {
 
     private ParserUtils() {
+    }
+
+    public static BallerinaFile buildLangModel(Path sourceFilePath) {
+        ANTLRInputStream antlrInputStream = getAntlrInputStream(sourceFilePath);
+
+        try {
+            // Setting the name of the source file being parsed, to the ANTLR input stream.
+            // This is required by the parser-error strategy.
+            antlrInputStream.name = getFileName(sourceFilePath);
+
+            BallerinaLexer ballerinaLexer = new BallerinaLexer(antlrInputStream);
+            CommonTokenStream ballerinaToken = new CommonTokenStream(ballerinaLexer);
+
+            BallerinaParser ballerinaParser = new BallerinaParser(ballerinaToken);
+            ballerinaParser.setErrorHandler(new BallerinaParserErrorStrategy());
+
+            GlobalScope globalScope = GlobalScope.getInstance();
+            loadGlobalSymbols(globalScope);
+            BLangPackage bLangPackage = new BLangPackage(globalScope);
+
+            BLangModelBuilder bLangModelBuilder = new BLangModelBuilder(bLangPackage);
+            BLangAntlr4Listener ballerinaBaseListener = new BLangAntlr4Listener(bLangModelBuilder);
+            ballerinaParser.addParseListener(ballerinaBaseListener);
+            ballerinaParser.compilationUnit();
+            BallerinaFile balFile = bLangModelBuilder.build();
+
+            BuiltInNativeConstructLoader.loadConstructs(globalScope);
+
+            SemanticAnalyzer semanticAnalyzer = new SemanticAnalyzer(balFile, bLangPackage);
+            balFile.accept(semanticAnalyzer);
+
+            return balFile;
+        } catch (ParseCancellationException | SemanticException | LinkerException e) {
+            throw new BallerinaException(e.getMessage());
+        } catch (Throwable e) {
+            throw new BallerinaException(getFileName(sourceFilePath) + ": " + e.getMessage());
+        }
+    }
+
+    public static String getFileName(Path sourceFilePath) {
+        Path fileNamePath = sourceFilePath.getFileName();
+        return (fileNamePath != null) ? fileNamePath.toString() : sourceFilePath.toString();
+    }
+
+    private static ANTLRInputStream getAntlrInputStream(Path sourceFilePath) {
+        try {
+            InputStream inputStream = new FileInputStream(sourceFilePath.toFile());
+            return new ANTLRInputStream(inputStream);
+        } catch (FileNotFoundException e) {
+            throw new BallerinaException("ballerina: no such file or directory '" + getFileName(sourceFilePath) + "'");
+        } catch (Throwable e) {
+            throw createUsageException(
+                    "error reading file or directory'" + getFileName(sourceFilePath) + "': " + e.getMessage());
+        }
+    }
+
+    private static void loadGlobalSymbols(GlobalScope globalScope) {
+        BTypes.loadBuiltInTypes(globalScope);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,26 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.wso2.ballerina</groupId>
+                <artifactId>annotation-processor</artifactId>
+                <version>${ballerina.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.ballerina</groupId>
+                <artifactId>ballerina-core</artifactId>
+                <version>${ballerina.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.ballerina</groupId>
+                <artifactId>ballerina-launcher</artifactId>
+                <version>${ballerina.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.antlr</groupId>
+                <artifactId>antlr4-runtime</artifactId>
+                <version>${antlr4.runtime.version}</version>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>
@@ -69,10 +89,8 @@
     </build>
 
     <properties>
+        <ballerina.version>0.8.0-M4</ballerina.version>
 
-        <ballerina.core.version>0.8.0-SNAPSHOT</ballerina.core.version>
-
-        <ballerina.launcher.version>0.8.0-SNAPSHOT</ballerina.launcher.version>
         <com.beust.jcommander.version>1.60</com.beust.jcommander.version>
 
         <testerina.version>0.8.0-SNAPSHOT</testerina.version>


### PR DESCRIPTION
This PR contains,

1. The MockerinaRegistry that stores the deployed and yet to be deployed BallerinaFiles. 
        - This is needed since we need to maintain the list of services user ask to deploy via       mock::startService

2. mock::startService native function impl to start services