### PR TITLE
AssertFail support added, minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,12 @@ Note the package hierarchy in above files.
 Following is a sample console output. 
 
 ```
+test 'testInt' failed: <Detail error message>
+ 
 result:  
- tests run: 1, passed: 0, failed: 1
-
+tests run: 1, passed: 0, failed: 1
 failed tests:
- testAddTwoIntegersWithNumber: AddTwoIntegers for positive numbers failed
- testAddTwoIntegersWithZero: AddTwoIntegers for zero value failed 
+ testInt: <Detail error message>
 ```
 
 ### Running Samples

--- a/modules/testerina-core/pom.xml
+++ b/modules/testerina-core/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>testerina-core</artifactId>
     <packaging>jar</packaging>
-    <name>WSO2 Testerina - Core</name>
+    <name>Testerina - Core</name>
 
     <url>http://wso2.org</url>
 
@@ -62,7 +62,7 @@
         </resources>
 
         <plugins>
-            <!-- For creating the ballerina structure from connector structure -->
+            <!-- For creating the ballerina structure from testerina structure -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -140,6 +140,7 @@
             <plugin>
                 <groupId>org.ballerinalang</groupId>
                 <artifactId>docerina-maven-plugin</artifactId>
+                <version>${docerina.maven.plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>compile</phase>

--- a/modules/testerina-core/src/main/ballerina/ballerina/test/assert.bal
+++ b/modules/testerina-core/src/main/ballerina/ballerina/test/assert.bal
@@ -269,3 +269,15 @@ function assertEquals(int[] actual, int[] expected, string errorMessage) {
     }
 }
 
+@doc:Description("Assert failure is triggered based on user discretion.")
+function assertFail() {
+    throw createBallerinaException("Assert failure", assertFailureErrorCategory);
+}
+
+@doc:Description("Assert failure is triggered based on user discretion.
+                  BallerinaException is thrown with the given errorMessage")
+@doc:Param("errorMessage: Assertion error message")
+function assertFail(string errorMessage) {
+    throw createBallerinaException(errorMessage, assertFailureErrorCategory);
+}
+

--- a/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestCmd.java
+++ b/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestCmd.java
@@ -66,7 +66,7 @@ public class TestCmd implements BLauncherCmd {
         }
 
         if (sourceFileList == null || sourceFileList.size() == 0) {
-            throw LauncherUtils.createUsageException("no ballerina program or folder given to run tests");
+            throw LauncherUtils.createUsageException("no ballerina program or directory given to run tests");
         }
 
         if (mock) {

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <docerina.maven.plugin.version>0.8.1</docerina.maven.plugin.version>
 
         <com.beust.jcommander.version>1.60</com.beust.jcommander.version>
-        <owasp.dependency.check.maven.version>1.4.5</owasp.dependency.check.maven.version>
+        <owasp.dependency.check.maven.version>1.4.0</owasp.dependency.check.maven.version>
         <mvn.processor.plugin.version>2.2.4</mvn.processor.plugin.version>
         <mvn.exec.plugin.version>1.1.1</mvn.exec.plugin.version>
         <mvn.resource.plugins.version>3.0.2</mvn.resource.plugins.version>


### PR DESCRIPTION
- Users can fail a test upon their discretion with the support of new AssertFail functionality
- Minor fixes in README.md file
- Missing docerina.maven.plugin.version added to parent pom.xml
- owasp.dependency.check.maven.version downgraded to 1.4.0 to be compatible with maven 3.0.x